### PR TITLE
Fix for: Only variables should be passed by reference

### DIFF
--- a/TranslatorPlugin.inc.php
+++ b/TranslatorPlugin.inc.php
@@ -70,7 +70,8 @@ class TranslatorPlugin extends GenericPlugin {
 			case 'plugins.generic.translator.controllers.listbuilder.LocaleFileListbuilderHandler':
 				// Allow the static page grid handler to get the plugin object
 				import($component);
-				$className = array_pop(explode('.', $component));
+				$componentParts = explode('.', $component);
+				$className = array_pop($componentParts);
 				$className::setPlugin($this);
 				return true;
 		}


### PR DESCRIPTION
Hi. We got the following notice on PHP 7.1.29 and OJS 3.1.2.0:

```
PHP Notice:  Only variables should be passed by reference in /www/var/data/ojs/htdocs/plugins/generic/translator/TranslatorPlugin.inc.php on line 73
```

Which in turn caused the Translator tab to not show up. This seems to fix it.