### PR TITLE
Fix LocaleGridRow::initialize() declaration

### DIFF
--- a/controllers/grid/LocaleGridRow.inc.php
+++ b/controllers/grid/LocaleGridRow.inc.php
@@ -35,8 +35,8 @@ class LocaleGridRow extends GridRow {
 	/**
 	 * @copydoc GridRow::initialize()
 	 */
-	function initialize($request) {
-		parent::initialize($request);
+	function initialize($request, $template = NULL) {
+		parent::initialize($request, $template);
 		$router = $request->getRouter();
 
 		$actionArgs = array(


### PR DESCRIPTION
Another one. We got the following warning:

```
PHP Warning:  Declaration of LocaleGridRow::initialize($request) should be compatible with GridRow::initialize($request, $template = NULL) in /.../plugins/generic/translator/controllers/grid/LocaleGridRow.inc.php on line 74
```

I'm not sure if this is a *proper* fix, but it makes the plugin work for us again. On PHP 7.1.29 and OJS 3.1.2.0
